### PR TITLE
Modal consistency

### DIFF
--- a/frontend/src/components/AddKnowledgeModal.vue
+++ b/frontend/src/components/AddKnowledgeModal.vue
@@ -1,38 +1,22 @@
 <template>
-  <div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
-    <div class="bg-white p-6 rounded shadow-lg w-1/3">
-      <h2 class="text-2xl mb-4">{{ isEditing ? 'Edit Knowledge' : 'Add Knowledge' }}</h2>
-      <form @submit.prevent="handleSubmit">
-        <div class="mb-4">
-          <label for="title" class="block text-gray-700">Title</label>
-          <input v-model="title" id="title" type="text" class="mt-1 block w-full p-2 border rounded" />
-          <span v-if="errors.title" class="text-red-500">{{ errors.title }}</span>
-        </div>
-        <div class="mb-4">
-          <label for="description" class="block text-gray-700">Description</label>
-          <textarea v-model="description" id="description" class="mt-1 block w-full p-2 border rounded" rows="5"></textarea>
-          <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
-        </div>
-        <div class="flex justify-end">
-          <button type="button" @click="$emit('close')" class="bg-gray-500 text-white p-2 rounded mr-2">Cancel</button>
-          <button type="submit" :disabled="isLoading" class="bg-blue-500 text-white p-2 rounded">
-            <span v-if="isLoading">Loading...</span>
-            <span v-else>Submit</span>
-          </button>
-        </div>
-      </form>
-      <div v-if="apiResponse" class="mt-4">
-        <p>{{ apiResponse.message }}</p>
-      </div>
-    </div>
-  </div>
+  <BaseModal
+    :confirm_text="isEditing ? 'Save' : 'Add'"
+    cancel_text="Cancel"
+    :content="modalContent"
+    @close="$emit('close')"
+    @confirm="handleSubmit"
+  />
 </template>
 
 <script>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
+import BaseModal from './BaseModal.vue'
 
 export default {
   name: 'AddKnowledgeModal',
+  components: {
+    BaseModal
+  },
   props: {
     initialTitle: {
       type: String,
@@ -113,13 +97,35 @@ export default {
       }
     }
 
+    const modalContent = computed(() => `
+      <div>
+        <h2 class="text-2xl mb-4">${props.isEditing ? 'Edit Knowledge' : 'Add Knowledge'}</h2>
+        <form @submit.prevent="handleSubmit">
+          <div class="mb-4">
+            <label for="title" class="block text-gray-700">Title</label>
+            <input v-model="title" id="title" type="text" class="mt-1 block w-full p-2 border rounded" />
+            <span v-if="errors.title" class="text-red-500">{{ errors.title }}</span>
+          </div>
+          <div class="mb-4">
+            <label for="description" class="block text-gray-700">Description</label>
+            <textarea v-model="description" id="description" class="mt-1 block w-full p-2 border rounded" rows="5"></textarea>
+            <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
+          </div>
+        </form>
+        <div v-if="apiResponse" class="mt-4">
+          <p>{{ apiResponse.message }}</p>
+        </div>
+      </div>
+    `)
+
     return {
       title,
       description,
       errors,
       isLoading,
       apiResponse,
-      handleSubmit
+      handleSubmit,
+      modalContent
     }
   }
 }

--- a/frontend/src/components/AddKnowledgeModal.vue
+++ b/frontend/src/components/AddKnowledgeModal.vue
@@ -2,14 +2,27 @@
   <BaseModal
     :confirm_text="isEditing ? 'Save' : 'Add'"
     cancel_text="Cancel"
-    :content="modalContent"
     @close="$emit('close')"
     @confirm="handleSubmit"
-  />
+  >
+    <div>
+      <h2 class="text-2xl mb-4">{{header}}</h2>
+        <div class="mb-4">
+          <label for="title" class="block text-gray-700">Title</label>
+          <input v-model="title" id="title" type="text" class="mt-1 block w-full p-2 border rounded" />
+          <span v-if="errors.title" class="text-red-500">{{ errors.title }}</span>
+        </div>
+        <div class="mb-4">
+          <label for="description" class="block text-gray-700">Description</label>
+          <textarea v-model="description" id="description" class="mt-1 block w-full p-2 border rounded" rows="5"></textarea>
+          <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
+        </div>
+    </div>
+  </BaseModal>
 </template>
 
 <script>
-import { ref, watch, computed } from 'vue'
+import { ref, watch } from 'vue'
 import BaseModal from './BaseModal.vue'
 
 export default {
@@ -38,6 +51,7 @@ export default {
   setup(props, { emit }) {
     const title = ref(props.initialTitle)
     const description = ref(props.initialDescription)
+    const header = ref('Add Knowledge')
     const errors = ref({})
     const isLoading = ref(false)
     const apiResponse = ref(null)
@@ -48,6 +62,12 @@ export default {
 
     watch(() => props.initialDescription, (newDescription) => {
       description.value = newDescription
+    })
+
+    watch(() => props.isEditing, (isEditing) => {
+      if (isEditing) {
+        header.value = 'Edit Knowledge'
+      }
     })
 
     function validateForm() {
@@ -97,35 +117,13 @@ export default {
       }
     }
 
-    const modalContent = computed(() => `
-      <div>
-        <h2 class="text-2xl mb-4">${props.isEditing ? 'Edit Knowledge' : 'Add Knowledge'}</h2>
-        <form @submit.prevent="handleSubmit">
-          <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input v-model="title" id="title" type="text" class="mt-1 block w-full p-2 border rounded" />
-            <span v-if="errors.title" class="text-red-500">{{ errors.title }}</span>
-          </div>
-          <div class="mb-4">
-            <label for="description" class="block text-gray-700">Description</label>
-            <textarea v-model="description" id="description" class="mt-1 block w-full p-2 border rounded" rows="5"></textarea>
-            <span v-if="errors.description" class="text-red-500">{{ errors.description }}</span>
-          </div>
-        </form>
-        <div v-if="apiResponse" class="mt-4">
-          <p>{{ apiResponse.message }}</p>
-        </div>
-      </div>
-    `)
-
     return {
       title,
       description,
       errors,
       isLoading,
       apiResponse,
-      handleSubmit,
-      modalContent
+      handleSubmit
     }
   }
 }

--- a/frontend/src/components/AddKnowledgeModal.vue
+++ b/frontend/src/components/AddKnowledgeModal.vue
@@ -2,6 +2,7 @@
   <BaseModal
     :confirm_text="isEditing ? 'Save' : 'Add'"
     cancel_text="Cancel"
+    :serverMessage="apiResponse?.message"
     @close="$emit('close')"
     @confirm="handleSubmit"
   >

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -6,7 +6,7 @@
       </button>
       <slot></slot>
       <div class="mt-4 flex justify-start button-container">
-        <button v-if="confirm_text" @click="confirmAction" class="bg-blue-500 text-white p-2 rounded mr-2" ref="confirmButton">{{ confirm_text }}</button>
+        <button v-if="confirm_text" @click="confirmAction" :disabled="isConfirming" class="bg-blue-500 text-white p-2 rounded mr-2" ref="confirmButton">{{ confirm_text }}</button>
         <button v-if="cancel_text" @click="closeModal" class="bg-gray-500 text-white p-2 rounded mr-2" ref="cancelButton">{{ cancel_text }}</button>
       </div>
       <div v-if="serverMessage" class="mt-4 text-blue-500">{{ serverMessage }}</div>
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 
 export default {
   name: 'BaseModal',
@@ -37,14 +37,22 @@ export default {
     const confirmButton = ref(null)
     const cancelButton = ref(null)
     const closeButton = ref(null)
+    const isConfirming = ref(false)
 
     function closeModal() {
       emit('close')
     }
 
     function confirmAction() {
+      isConfirming.value = true
       emit('confirm')
     }
+
+    watch(() => props.serverMessage, (newVal) => {
+      if (newVal) {
+        isConfirming.value = false
+      }
+    })
 
     onMounted(() => {
       if (confirmButton.value) {
@@ -61,7 +69,8 @@ export default {
       confirmAction,
       confirmButton,
       cancelButton,
-      closeButton
+      closeButton,
+      isConfirming
     }
   }
 }

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -5,10 +5,9 @@
         <i class="fas fa-times"></i>
       </button>
       <div v-if="content" v-html="content"></div>
-      <div class="mt-4 flex justify-end">
+      <div class="mt-4 flex justify-start button-container">
         <button v-if="confirm_text" @click="confirmAction" class="bg-blue-500 text-white p-2 rounded mr-2" ref="confirmButton">{{ confirm_text }}</button>
         <button v-if="cancel_text" @click="closeModal" class="bg-gray-500 text-white p-2 rounded mr-2" ref="cancelButton">{{ cancel_text }}</button>
-        <button @click="closeModal" class="bg-gray-500 text-white p-2 rounded" ref="closeButton">Close</button>
       </div>
       <div v-if="serverMessage" class="mt-4 text-blue-500">{{ serverMessage }}</div>
     </div>
@@ -73,5 +72,9 @@ export default {
 </script>
 
 <style scoped>
+.button-container {
+  display: flex;
+  flex-direction: row-reverse;
+}
 /* Add any additional styling here if needed */
 </style>

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -4,7 +4,7 @@
       <button @click="closeModal" class="absolute top-2 right-2 text-gray-500 hover:text-gray-700">
         <i class="fas fa-times"></i>
       </button>
-      <div v-if="content" v-html="content"></div>
+      <slot></slot>
       <div class="mt-4 flex justify-start button-container">
         <button v-if="confirm_text" @click="confirmAction" class="bg-blue-500 text-white p-2 rounded mr-2" ref="confirmButton">{{ confirm_text }}</button>
         <button v-if="cancel_text" @click="closeModal" class="bg-gray-500 text-white p-2 rounded mr-2" ref="cancelButton">{{ cancel_text }}</button>
@@ -25,10 +25,6 @@ export default {
       default: ''
     },
     cancel_text: {
-      type: String,
-      default: ''
-    },
-    content: {
       type: String,
       default: ''
     },

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50" @click.self="closeModal" @keydown.esc="closeModal" tabindex="0">
+    <div class="bg-white p-6 rounded shadow-lg w-1/3 relative">
+      <button @click="closeModal" class="absolute top-2 right-2 text-gray-500 hover:text-gray-700">
+        <i class="fas fa-times"></i>
+      </button>
+      <div v-if="content" v-html="content"></div>
+      <div class="mt-4 flex justify-end">
+        <button v-if="confirm_text" @click="confirmAction" class="bg-blue-500 text-white p-2 rounded mr-2" ref="confirmButton">{{ confirm_text }}</button>
+        <button v-if="cancel_text" @click="closeModal" class="bg-gray-500 text-white p-2 rounded mr-2" ref="cancelButton">{{ cancel_text }}</button>
+        <button @click="closeModal" class="bg-gray-500 text-white p-2 rounded" ref="closeButton">Close</button>
+      </div>
+      <div v-if="serverMessage" class="mt-4 text-blue-500">{{ serverMessage }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue'
+
+export default {
+  name: 'BaseModal',
+  props: {
+    confirm_text: {
+      type: String,
+      default: ''
+    },
+    cancel_text: {
+      type: String,
+      default: ''
+    },
+    content: {
+      type: String,
+      default: ''
+    },
+    serverMessage: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(props, { emit }) {
+    const confirmButton = ref(null)
+    const cancelButton = ref(null)
+    const closeButton = ref(null)
+
+    function closeModal() {
+      emit('close')
+    }
+
+    function confirmAction() {
+      emit('confirm')
+    }
+
+    onMounted(() => {
+      if (confirmButton.value) {
+        confirmButton.value.focus()
+      } else if (cancelButton.value) {
+        cancelButton.value.focus()
+      } else if (closeButton.value) {
+        closeButton.value.focus()
+      }
+    })
+
+    return {
+      closeModal,
+      confirmAction,
+      confirmButton,
+      cancelButton,
+      closeButton
+    }
+  }
+}
+</script>
+
+<style scoped>
+/* Add any additional styling here if needed */
+</style>

--- a/frontend/src/components/DeleteConfirmationModal.vue
+++ b/frontend/src/components/DeleteConfirmationModal.vue
@@ -2,6 +2,7 @@
   <BaseModal
     confirm_text="Confirm"
     cancel_text="Cancel"
+    :serverMessage="message"
     @close="$emit('close')"
     @confirm="handleConfirm"
   >

--- a/frontend/src/components/DeleteConfirmationModal.vue
+++ b/frontend/src/components/DeleteConfirmationModal.vue
@@ -1,22 +1,22 @@
 <template>
-  <div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
-    <div class="bg-white p-6 rounded shadow-lg w-1/3">
-      <h2 class="text-2xl mb-4">Delete Confirmation</h2>
-      <p>Are you sure you want to delete this knowledge item?</p>
-      <p v-if="message" class="mt-4 text-red-500">{{ message }}</p>
-      <div class="flex justify-end mt-4">
-        <button @click="handleCancel" class="bg-gray-500 text-white p-2 rounded mr-2">Cancel</button>
-        <button @click="handleConfirm" class="bg-red-500 text-white p-2 rounded">Confirm</button>
-      </div>
-    </div>
-  </div>
+  <BaseModal
+    confirm_text="Confirm"
+    cancel_text="Cancel"
+    content="Are you sure you want to delete this knowledge item?"
+    @close="$emit('close')"
+    @confirm="handleConfirm"
+  />
 </template>
 
 <script>
 import { ref } from 'vue'
+import BaseModal from './BaseModal.vue'
 
 export default {
   name: 'DeleteConfirmationModal',
+  components: {
+    BaseModal
+  },
   props: {
     knowledgeItem: {
       type: Object,
@@ -26,10 +26,6 @@ export default {
   setup(props, { emit }) {
     const isLoading = ref(false)
     const message = ref('')
-
-    function handleCancel() {
-      emit('close')
-    }
 
     async function handleConfirm() {
       isLoading.value = true
@@ -60,7 +56,6 @@ export default {
     }
 
     return {
-      handleCancel,
       handleConfirm,
       isLoading,
       message

--- a/frontend/src/components/DeleteConfirmationModal.vue
+++ b/frontend/src/components/DeleteConfirmationModal.vue
@@ -2,10 +2,11 @@
   <BaseModal
     confirm_text="Confirm"
     cancel_text="Cancel"
-    content="Are you sure you want to delete this knowledge item?"
     @close="$emit('close')"
     @confirm="handleConfirm"
-  />
+  >
+  <p>Are you sure you want to delete this knowledge item?</p>
+  </BaseModal>
 </template>
 
 <script>


### PR DESCRIPTION
Fixes #25

Add a new `BaseModal.vue` component and update existing modals to use it.

* **BaseModal.vue**:
  - Create a new `BaseModal.vue` component with the specified functionality and props.
  - Implement the ability to close the modal by clicking the "x", clicking the background, or hitting "esc".
  - Display server messages consistently in blue text under the button.
  - Ensure the tab order of buttons is `<confirm>`, `<cancel>`, `<close>`.

* **AddKnowledgeModal.vue**:
  - Update to use `BaseModal` and pass `confirm_text`, `cancel_text`, and `content` as props.
  - Remove the existing modal structure and replace it with `BaseModal`.

* **DeleteConfirmationModal.vue**:
  - Update to use `BaseModal` and pass `confirm_text`, `cancel_text`, and `content` as props.
  - Remove the existing modal structure and replace it with `BaseModal`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/n3rdgir1/elysian-mirror/pull/26?shareId=48913633-fdb0-4e2d-bb98-03d14b06f9cb).