### PR TITLE
Move server messages to app notifications

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -22,7 +22,7 @@
               </router-link>
             </li>
             <li class="mb-4">
-              <router-link to="/generate-ideas" class="flex flex-col items-center">
+              <router-link to="/generate-ideas" @click="handleServerMessage" class="flex flex-col items-center">
                 <i :class="['fas fa-lightbulb', { 'text-2xl': isCollapsed, 'text-4xl': !isCollapsed }]"></i>
                 <span v-if="!isCollapsed" class="mt-2 text-center">Generate<br>Ideas</span>
               </router-link>
@@ -43,12 +43,12 @@
         </nav>
       </aside>
       <main class="flex-1 ml-16">
-        <router-view />
+        <router-view @server-message="handleServerMessage" />
       </main>
     </div>
-    <AddKnowledgeModal v-if="isAddKnowledgeModalOpen" @close="closeAddKnowledgeModal" />
-    <div class="fixed top-0 right-0 m-4">
-      <Notification
+    <AddKnowledgeModal v-if="isAddKnowledgeModalOpen" @close="closeAddKnowledgeModal" @server-message="handleServerMessage" />
+    <div class="fixed top-0 right-0 m-4 z-20">
+      <AppNotification
         v-for="notification in notifications"
         :key="notification.id"
         :message="notification.message"
@@ -63,13 +63,13 @@
 <script>
 import { ref } from 'vue'
 import AddKnowledgeModal from './components/AddKnowledgeModal.vue'
-import Notification from './components/Notification.vue'
+import AppNotification from './components/Notification.vue' // Updated import
 
 export default {
   name: 'App',
   components: {
     AddKnowledgeModal,
-    Notification
+    AppNotification // Updated component name
   },
   setup() {
     const isCollapsed = ref(true) // Set to true to collapse by default
@@ -97,6 +97,10 @@ export default {
       notifications.value = notifications.value.filter(notification => notification.id !== id)
     }
 
+    function handleServerMessage({ message, type }) {
+      addNotification(message, type)
+    }
+
     return {
       isCollapsed,
       toggleMenu,
@@ -105,7 +109,8 @@ export default {
       closeAddKnowledgeModal,
       notifications,
       addNotification,
-      removeNotification
+      removeNotification,
+      handleServerMessage
     }
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -47,21 +47,34 @@
       </main>
     </div>
     <AddKnowledgeModal v-if="isAddKnowledgeModalOpen" @close="closeAddKnowledgeModal" />
+    <div class="fixed top-0 right-0 m-4">
+      <Notification
+        v-for="notification in notifications"
+        :key="notification.id"
+        :message="notification.message"
+        :type="notification.type"
+        :id="notification.id"
+        @close="removeNotification"
+      />
+    </div>
   </div>
 </template>
 
 <script>
 import { ref } from 'vue'
 import AddKnowledgeModal from './components/AddKnowledgeModal.vue'
+import Notification from './components/Notification.vue'
 
 export default {
   name: 'App',
   components: {
-    AddKnowledgeModal
+    AddKnowledgeModal,
+    Notification
   },
   setup() {
     const isCollapsed = ref(true) // Set to true to collapse by default
     const isAddKnowledgeModalOpen = ref(false)
+    const notifications = ref([])
 
     function toggleMenu() {
       isCollapsed.value = !isCollapsed.value
@@ -75,12 +88,24 @@ export default {
       isAddKnowledgeModalOpen.value = false
     }
 
+    function addNotification(message, type) {
+      const id = Date.now()
+      notifications.value.push({ id, message, type })
+    }
+
+    function removeNotification(id) {
+      notifications.value = notifications.value.filter(notification => notification.id !== id)
+    }
+
     return {
       isCollapsed,
       toggleMenu,
       isAddKnowledgeModalOpen,
       openAddKnowledgeModal,
-      closeAddKnowledgeModal
+      closeAddKnowledgeModal,
+      notifications,
+      addNotification,
+      removeNotification
     }
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -22,7 +22,7 @@
               </router-link>
             </li>
             <li class="mb-4">
-              <router-link to="/generate-ideas" @click="handleServerMessage" class="flex flex-col items-center">
+              <router-link to="/generate-ideas" class="flex flex-col items-center">
                 <i :class="['fas fa-lightbulb', { 'text-2xl': isCollapsed, 'text-4xl': !isCollapsed }]"></i>
                 <span v-if="!isCollapsed" class="mt-2 text-center">Generate<br>Ideas</span>
               </router-link>

--- a/frontend/src/components/AddKnowledgeModal.vue
+++ b/frontend/src/components/AddKnowledgeModal.vue
@@ -108,18 +108,13 @@ export default {
         apiResponse.value = data
 
         // Emit the server message and type
-        emit('server-message', { message: data.message, type: data.success ? 'success' : 'error' })
-
-        // Close the modal if the server message is a success
-        if (data.success) {
-          emit('close')
-        }
+        emit('server-message', { message: data.message, type: 'success' })
 
         title.value = ''
         description.value = ''
-        if (!props.isEditing) {
-          emit('refresh')
-        }
+        emit('refresh')
+        emit('close')
+
       } catch (error) {
         apiResponse.value = { message: 'Error: ' + error.message }
         emit('server-message', { message: 'Error: ' + error.message, type: 'error' })
@@ -134,7 +129,8 @@ export default {
       errors,
       isLoading,
       apiResponse,
-      handleSubmit
+      handleSubmit,
+      header // Add header to the return object
     }
   }
 }

--- a/frontend/src/components/AddKnowledgeModal.vue
+++ b/frontend/src/components/AddKnowledgeModal.vue
@@ -106,6 +106,15 @@ export default {
 
         const data = await response.json()
         apiResponse.value = data
+
+        // Emit the server message and type
+        emit('server-message', { message: data.message, type: data.success ? 'success' : 'error' })
+
+        // Close the modal if the server message is a success
+        if (data.success) {
+          emit('close')
+        }
+
         title.value = ''
         description.value = ''
         if (!props.isEditing) {
@@ -113,6 +122,7 @@ export default {
         }
       } catch (error) {
         apiResponse.value = { message: 'Error: ' + error.message }
+        emit('server-message', { message: 'Error: ' + error.message, type: 'error' })
       } finally {
         isLoading.value = false
       }

--- a/frontend/src/components/BaseModal.vue
+++ b/frontend/src/components/BaseModal.vue
@@ -9,7 +9,6 @@
         <button v-if="confirm_text" @click="confirmAction" :disabled="isConfirming" class="bg-blue-500 text-white p-2 rounded mr-2" ref="confirmButton">{{ confirm_text }}</button>
         <button v-if="cancel_text" @click="closeModal" class="bg-gray-500 text-white p-2 rounded mr-2" ref="cancelButton">{{ cancel_text }}</button>
       </div>
-      <div v-if="serverMessage" class="mt-4 text-blue-500">{{ serverMessage }}</div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/DeleteConfirmationModal.vue
+++ b/frontend/src/components/DeleteConfirmationModal.vue
@@ -48,10 +48,17 @@ export default {
         }
 
         message.value = data.message || 'Knowledge item deleted successfully'
+        emit('server-message', { message: data.message || 'Knowledge item deleted successfully', type: 'success' })
+
+        if (data.success) {
+          emit('close')
+        }
+
         emit('confirm')
       } catch (error) {
         console.error('Error:', error)
         message.value = error.message
+        emit('server-message', { message: error.message, type: 'error' })
       } finally {
         isLoading.value = false
       }

--- a/frontend/src/components/DeleteConfirmationModal.vue
+++ b/frontend/src/components/DeleteConfirmationModal.vue
@@ -5,6 +5,7 @@
     :serverMessage="message"
     @close="$emit('close')"
     @confirm="handleConfirm"
+    @server-message="$emit('server-message', $event)"
   >
   <p>Are you sure you want to delete this knowledge item?</p>
   </BaseModal>
@@ -50,11 +51,9 @@ export default {
         message.value = data.message || 'Knowledge item deleted successfully'
         emit('server-message', { message: data.message || 'Knowledge item deleted successfully', type: 'success' })
 
-        if (data.success) {
-          emit('close')
-        }
+        emit('confirm', props.knowledgeItem.id)
+        emit('close')
 
-        emit('confirm')
       } catch (error) {
         console.error('Error:', error)
         message.value = error.message

--- a/frontend/src/components/Notification.vue
+++ b/frontend/src/components/Notification.vue
@@ -1,0 +1,75 @@
+<template>
+  <div :class="['notification', type]" @click="closeNotification">
+    <i :class="iconClass"></i>
+    <span>{{ message }}</span>
+    <button @click.stop="closeNotification">x</button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Notification',
+  props: {
+    message: {
+      type: String,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true
+    },
+    id: {
+      type: Number,
+      required: true
+    }
+  },
+  computed: {
+    iconClass() {
+      return this.type === 'success' ? 'fas fa-check-circle text-green-500' : 'fas fa-times-circle text-red-500';
+    }
+  },
+  mounted() {
+    this.autoClose();
+  },
+  methods: {
+    closeNotification() {
+      this.$emit('close', this.id);
+    },
+    autoClose() {
+      setTimeout(() => {
+        this.closeNotification();
+      }, 5000);
+    }
+  }
+}
+</script>
+
+<style scoped>
+.notification {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  margin: 1rem 0;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+}
+.notification.success {
+  background-color: #d4edda;
+  color: #155724;
+}
+.notification.error {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+.notification i {
+  margin-right: 0.5rem;
+}
+.notification button {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/Notification.vue
+++ b/frontend/src/components/Notification.vue
@@ -8,7 +8,7 @@
 
 <script>
 export default {
-  name: 'Notification',
+  name: 'AppNotification',
   props: {
     message: {
       type: String,
@@ -71,5 +71,6 @@ export default {
   border: none;
   font-size: 1.2rem;
   cursor: pointer;
+  margin-left: 0.5rem;
 }
 </style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,5 +3,6 @@ import App from './App.vue'
 import router from './router'
 import './assets/tailwind.css'
 import AddKnowledgeModal from './components/AddKnowledgeModal.vue'
+import Notification from './components/Notification.vue'
 
-createApp(App).use(router).component('AddKnowledgeModal', AddKnowledgeModal).mount('#app')
+createApp(App).use(router).component('AddKnowledgeModal', AddKnowledgeModal).component('Notification', Notification).mount('#app')

--- a/frontend/src/views/GenerateIdeas.vue
+++ b/frontend/src/views/GenerateIdeas.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="h-full w-full">
     <ChatWindow title="Generate Ideas" apiEndpoint="/generate" @add-to-knowledge="openAddKnowledgeModal" :showAddToKnowledgeButton="true" />
-    <AddKnowledgeModal v-if="isAddKnowledgeModalOpen" @close="closeAddKnowledgeModal" :initialTitle="knowledgeTitle" :initialDescription="knowledgeDescription" />
+    <AddKnowledgeModal
+      v-if="isAddKnowledgeModalOpen"
+      @close="closeAddKnowledgeModal"
+      :initialTitle="knowledgeTitle"
+      :initialDescription="knowledgeDescription"
+      @server-message="handleServerMessage"
+    />
   </div>
 </template>
 
@@ -16,7 +22,7 @@ export default {
     ChatWindow,
     AddKnowledgeModal
   },
-  setup() {
+  setup(props, {emit}) {
     const isAddKnowledgeModalOpen = ref(false)
     const knowledgeTitle = ref('')
     const knowledgeDescription = ref('')
@@ -31,12 +37,17 @@ export default {
       isAddKnowledgeModalOpen.value = false
     }
 
+    function handleServerMessage({ message, type }) {
+      emit('server-message', { message, type })
+    }
+
     return {
       isAddKnowledgeModalOpen,
       knowledgeTitle,
       knowledgeDescription,
       openAddKnowledgeModal,
-      closeAddKnowledgeModal
+      closeAddKnowledgeModal,
+      handleServerMessage
     }
   }
 }

--- a/frontend/src/views/KnowledgeBase.vue
+++ b/frontend/src/views/KnowledgeBase.vue
@@ -34,6 +34,7 @@
       :knowledgeItem="knowledgeItemToDelete"
       @close="closeDeleteConfirmationModal"
       @confirm="deleteKnowledgeItem"
+      @server-message="handleServerMessage"
     />
     <AddKnowledgeModal
       v-if="isAddKnowledgeModalOpen"
@@ -43,6 +44,7 @@
       :isEditing="isEditing"
       :knowledgeId="knowledgeItemToEdit ? knowledgeItemToEdit.id : null"
       @refresh="fetchKnowledgeItems"
+      @server-message="handleServerMessage"
     />
   </div>
 </template>
@@ -58,7 +60,7 @@ export default {
     DeleteConfirmationModal,
     AddKnowledgeModal
   },
-  setup() {
+  setup(props, {emit}) {
     const knowledgeItems = ref([])
     const isDeleteConfirmationModalOpen = ref(false)
     const isAddKnowledgeModalOpen = ref(false)
@@ -95,6 +97,10 @@ export default {
       isAddKnowledgeModalOpen.value = true
     }
 
+    function deleteKnowledgeItem(item_id) {
+      knowledgeItems.value = knowledgeItems.value.filter(knowledgeItem => knowledgeItem.id !== item_id)
+    }
+
     function openEditKnowledgeModal(item) {
       knowledgeItemToEdit.value = item
       isEditing.value = true
@@ -115,6 +121,10 @@ export default {
       isDeleteConfirmationModalOpen.value = false
     }
 
+    function handleServerMessage({ message, type }) {
+      console.log('Message:', message, 'Type:', type)
+      emit('server-message', { message, type })
+    }
     onMounted(fetchKnowledgeItems)
 
     return {
@@ -131,7 +141,9 @@ export default {
       knowledgeItemToDelete,
       knowledgeItemToEdit,
       isEditing,
-      fetchKnowledgeItems
+      fetchKnowledgeItems,
+      handleServerMessage,
+      deleteKnowledgeItem
     }
   }
 }

--- a/frontend/src/views/KnowledgeBase.vue
+++ b/frontend/src/views/KnowledgeBase.vue
@@ -122,9 +122,9 @@ export default {
     }
 
     function handleServerMessage({ message, type }) {
-      console.log('Message:', message, 'Type:', type)
       emit('server-message', { message, type })
     }
+
     onMounted(fetchKnowledgeItems)
 
     return {


### PR DESCRIPTION
Fixes #27

Implement notifications for server messages and update modals to emit messages and close on success.

* **Notification Component**: Add `frontend/src/components/Notification.vue` to display notifications with props for `message`, `type`, and `id`. Include methods to close notifications manually and automatically after 5 seconds.
* **AddKnowledgeModal**: Modify `frontend/src/components/AddKnowledgeModal.vue` to emit server messages and types, and close the modal on success.
* **DeleteConfirmationModal**: Modify `frontend/src/components/DeleteConfirmationModal.vue` to emit server messages and types, and close the modal on success.
* **App Component**: Update `frontend/src/App.vue` to import and include the `Notification` component, add methods to handle displaying and removing notifications, and update the template to display notifications.
* **Main File**: Modify `frontend/src/main.js` to import and register the `Notification` component globally.
* **BaseModal**: Remove the display of the server message in `frontend/src/components/BaseModal.vue`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/n3rdgir1/elysian-mirror/pull/28?shareId=f5bc1a2e-588b-4dd0-8780-ea9571db0695).